### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.gz filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
The previous content of .gitattribute served essentially to define the parameters for git-lfs. However, the very large files have been suppressed from this repository, and the git-lfs specification creates an error. 

*.gz filter=lfs diff=lfs merge=lfs -text